### PR TITLE
Add slide preview route and template

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, request
+from flask import Flask, render_template, request, redirect, url_for
 
 app = Flask(__name__)
 
@@ -6,8 +6,17 @@ app = Flask(__name__)
 def index():
     if request.method == "POST":
         content = request.form["content"]
-        return render_template("index.html", content=content)
-    return render_template("index.html", content=None)
+        return redirect(url_for("preview", content=content))
+    return render_template("index.html")
+
+
+@app.route("/preview", methods=["GET", "POST"])
+def preview():
+    if request.method == "POST":
+        content = request.form.get("content", "")
+    else:
+        content = request.args.get("content", "")
+    return render_template("preview.html", content=content)
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,10 +10,5 @@
     <textarea name="content" rows="6" cols="60" placeholder="テキストを入力してください"></textarea><br>
     <button type="submit">送信</button>
   </form>
-
-  {% if content %}
-    <h2>入力内容:</h2>
-    <p>{{ content }}</p>
-  {% endif %}
 </body>
 </html>

--- a/templates/preview.html
+++ b/templates/preview.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>プレビュー</title>
+  <style>
+    .slide {
+      border: 1px solid #ccc;
+      border-radius: 8px;
+      padding: 60px;
+      margin: 20px auto;
+      width: 80%;
+      text-align: center;
+      font-size: 2em;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    }
+  </style>
+</head>
+<body>
+  {% for line in content.splitlines() %}
+    <div class="slide">{{ line }}</div>
+  {% endfor %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- redirect posted content from index to new /preview route
- show submitted text as simple card-like slides

## Testing
- `python -m pytest`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b12ffcf344832d82658b5e515a3e0d